### PR TITLE
screen: Custom URL handlers

### DIFF
--- a/src/terminal-screen.h
+++ b/src/terminal-screen.h
@@ -34,6 +34,13 @@ typedef enum {
   FLAVOR_NUMBER,
 } TerminalURLFlavor;
 
+typedef struct
+{
+  char *match;
+  char *rewrite;
+  VteRegex *_regex;
+} UrlHandler;
+
 /* Forward decls */
 typedef struct _TerminalScreenPopupInfo TerminalScreenPopupInfo;
 typedef struct _TerminalWindow        TerminalWindow;

--- a/src/terminal-util.h
+++ b/src/terminal-util.h
@@ -68,6 +68,8 @@ void terminal_util_add_proxy_env (GHashTable *env_table);
 GdkScreen *terminal_util_get_screen_by_display_name (const char *display_name,
                                                      int screen_number);
 
+GHashTable *terminal_util_load_url_handlers (void);
+
 char **terminal_util_get_etc_shells (void);
 
 gboolean terminal_util_get_is_shell (const char *command);


### PR DESCRIPTION
A utility function will check for $HOME/.gnome-terminal-customurls.rc.
This file should be in ini-like Key-value format with a Match and
Rewrite entry per group.

Example
```
[Diffs]
Match=D[0-9]{5,10}
Rewrite=https://pastebin.org/%s
```

- Match defines a PCRE2 regex to match screen text.
- Rewrite defines an `sprintf` like format string which will be expanded
  with a match when screen text is clicked.