### PR TITLE
Tell save-contents wont work on 3.30

### DIFF
--- a/src/org.gnome.Terminal.gschema.xml
+++ b/src/org.gnome.Terminal.gschema.xml
@@ -415,7 +415,7 @@
     </key>
     <key name="save-contents" type="s">
       <default>'disabled'</default>
-      <summary>Keyboard shortcut to save the current tab contents to file</summary>
+      <summary>Keyboard shortcut to save the current tab contents to file (only in developer versions, waiting vte to have async support)</summary>
     </key>
     <key name="export" type="s">
       <default>'disabled'</default>


### PR DESCRIPTION
Better user experience, so you don't have to search inside the source code or at internet

Thank you